### PR TITLE
experimental compute node lz4 compression

### DIFF
--- a/lz4.c
+++ b/lz4.c
@@ -100,10 +100,11 @@ void lz4_pack(const void * const in, const int * const size, void * const out, i
   /*printf("compSize in C: %d\n", *compSize);*/
 }
 
-void lz4_unpack(void * in, const size_t * const compSize, void * const out, const int * const size, const int * const ierr) {
+void lz4_unpack(void * in, const size_t * const compSize, void * const out, int * const size, const int * const ierr) {
   size_t offset=0;
   size_t offset_in=0;
   decBufIndex=0;
+  LZ4_resetStream(lz4Stream);
   LZ4_setStreamDecode(lz4StreamDecode,NULL,0);
   for(;;) {
     char cmpBuf[LZ4_COMPRESSBOUND(BLOCK_BYTES)];
@@ -142,4 +143,5 @@ void lz4_unpack(void * in, const size_t * const compSize, void * const out, cons
     }
     decBufIndex = (decBufIndex + 1) % 2;
   }
+  *size=offset;
 }

--- a/lz4.c
+++ b/lz4.c
@@ -1,0 +1,145 @@
+#include <stdio.h>
+#include <string.h>
+#include "./lz4/lib/lz4.h"
+
+static LZ4_stream_t lz4Stream_body; 
+static LZ4_stream_t* lz4Stream=&lz4Stream_body;
+static LZ4_streamDecode_t lz4StreamDecode_body;
+static LZ4_streamDecode_t* lz4StreamDecode = &lz4StreamDecode_body;
+enum {
+  BLOCK_BYTES = 8*1024
+};
+static char inpBuf[2][BLOCK_BYTES];
+static int inpBufIndex=0;
+static char decBuf[2][BLOCK_BYTES];
+static int  decBufIndex = 0;
+
+#ifndef FNAME_H
+#define FNAME_H
+
+/*
+   FORTRAN naming convention
+     default      cpgs_setup, etc.
+     -DUPCASE     CPGS_SETUP, etc.
+     -DUNDERSCORE cpgs_setup_, etc.
+*/
+
+#ifdef UPCASE
+#  define FORTRAN_NAME(low,up) up
+#else
+#ifdef UNDERSCORE
+#  define FORTRAN_NAME(low,up) low##_
+#else
+#  define FORTRAN_NAME(low,up) low
+#endif
+#endif
+
+#endif
+
+#define lz4_pack  FORTRAN_NAME(lz4_pack,  LZ4_PACK)
+#define lz4_unpack  FORTRAN_NAME(lz4_unpack,  LZ4_UNPACK)
+
+/** 
+ * Compress input buffer in to output buffer out. 
+ * The input and output buffer are assumed allocated and of size count with each
+ * element being of size n.
+ *
+ * @param in input buffer
+ * @param out output buffer
+ * @param n number of buffer elements
+ * @param size size of each elmement
+ * @param count number of elements
+ * @param ierr error code
+ */
+
+void lz4_pack(const void * const in, const int * const size, void * const out, int * const compSize, const int * const ierr) {
+  int i=0;
+
+  size_t ccount=0; // Bytes in the chunk to be compressed. This is BLOCK_BYTES besides for the last chunk
+  LZ4_resetStream(lz4Stream);
+  if(*size<0 || out==NULL || *size<0 ) {
+    printf("Error in Nek LZ4 compression\n");
+    return;
+  }
+  /*printf("size: %d\n", *size);*/
+  size_t lcount=(size_t) *size; // Bytes left to be compressed
+  /*printf("lcount: %zu\n", lcount);*/
+  size_t offset=0;
+  *compSize=0;
+  while (lcount > 0) {
+    if(lcount < BLOCK_BYTES) {
+      ccount=lcount;
+    }
+    else {
+      ccount=BLOCK_BYTES;
+    }
+    /*printf("offset: %zu\n",offset);*/
+    /*printf("ccount: %zu\n",ccount);*/
+    char* const inpPtr = inpBuf[inpBufIndex];
+    memcpy(inpPtr, in+offset, ccount);
+    /*printf("i: %d\n",i);*/
+    {
+      char cmpBuf[LZ4_COMPRESSBOUND(BLOCK_BYTES)];
+      const int cmpBytes = LZ4_compress_fast_continue(
+          lz4Stream, inpPtr, cmpBuf, ccount, sizeof(cmpBuf), 1);
+      if(cmpBytes <= 0) {
+        break;
+      }
+      /*printf("cmpBytes: %d\n",cmpBytes);*/
+      /*printf("compSize: %d\n",*compSize);*/
+      memcpy(out+*compSize, &cmpBytes, sizeof(cmpBytes));
+      memcpy(out+*compSize+sizeof(cmpBytes), &cmpBuf, cmpBytes);
+      *compSize=*compSize+cmpBytes+sizeof(cmpBytes);
+    }
+    inpBufIndex = (inpBufIndex + 1) % 2;
+    lcount=lcount-ccount;
+    offset=offset+ccount;
+    /*printf("----------------------\n");*/
+    i=i+1;
+  }
+  /*printf("compSize in C: %d\n", *compSize);*/
+}
+
+void lz4_unpack(void * in, const size_t * const compSize, void * const out, const int * const size, const int * const ierr) {
+  size_t offset=0;
+  size_t offset_in=0;
+  decBufIndex=0;
+  LZ4_setStreamDecode(lz4StreamDecode,NULL,0);
+  for(;;) {
+    char cmpBuf[LZ4_COMPRESSBOUND(BLOCK_BYTES)];
+    int cmpBytes = 0;
+    /*printf("offset_in+sizeof(cmpBytes): %d\n",offset_in+sizeof(cmpBytes));*/
+    /*printf("compSize: %d\n",*compSize);*/
+    int tmp=offset_in+sizeof(cmpBytes);
+    /*printf("tmp: %d\n", tmp);*/
+    /*printf("compSize: %d\n", *compSize);*/
+    if(tmp > (int) *compSize) {
+      break;
+    }
+    memcpy(&cmpBytes, in+offset_in, sizeof(cmpBytes));
+    /*printf("cmpBytes: %d\n",cmpBytes);*/
+    if(cmpBytes <= 0) {
+      /*printf("cmpBytes %d\n", cmpBytes);*/
+      break;
+    }
+
+    /*printf("lz4 cmpBytes %d\n", cmpBytes);*/
+    memcpy(&cmpBuf, in+offset_in+sizeof(cmpBytes), cmpBytes);
+    const size_t readCount1=0;
+    offset_in=offset_in+sizeof(cmpBytes)+cmpBytes;
+    /*printf("new offset_in: %zu\n", offset_in);*/
+
+    {
+      char* decPtr = decBuf[decBufIndex];
+      int decBytes = LZ4_decompress_safe_continue(
+          lz4StreamDecode, cmpBuf, decPtr, cmpBytes, BLOCK_BYTES);
+      if(decBytes <= 0) {
+        /*printf("lz4 decBytes: %d\n", decBytes);*/
+        break;
+      }
+      memcpy(out+offset, decPtr, (size_t) decBytes);
+      offset=offset+(size_t) decBytes;
+    }
+    decBufIndex = (decBufIndex + 1) % 2;
+  }
+}

--- a/makefile.template
+++ b/makefile.template
@@ -11,6 +11,7 @@ IFAMG=
 IFAMG_DUMP=
 IFNEKNEK=
 IFLZ4=
+IFLZ4COMMCOMP=
 IFMOAB=
 MOAB_DIR=
 F77=
@@ -115,6 +116,10 @@ endif
 ifeq ($(IFLZ4),true)
   lFLAGS := ${lFLAGS} $S/lz4/lib/liblz4.a 
 endif
+ifeq ($(IFLZ4COMMCOMP),true)
+  LZ4O := lz4.o
+  lFLAGS := ${lFLAGS} $S/lz4/lib/liblz4.a 
+endif
 # VISIT ########################################################################
 ifeq ($(IFVISIT),true)
   VISITNEK_INCLUDES:=-I$S/3rd_party
@@ -136,7 +141,7 @@ else
 	DUMMY:= $(shell rm -rf $S/mpif.h) 
 endif
 
-TMP1 = $(CORE) $(MXM) $(USR) $(MOABO) $(COMM_MPI) $(NEKNEKO) $(VISITO) $(LPACK)
+TMP1 = $(CORE) $(MXM) $(USR) $(MOABO) $(COMM_MPI) $(NEKNEKO) $(VISITO) $(LZ4O) $(LPACK)
 NOBJS_F = $(patsubst %,$(OBJDIR)/%,$(TMP1))
 TMP2 = $(JLCORE) $(JLINTP) $(CGS) 
 NOBJS_C = $(patsubst %,$(OBJDIR)/%,$(TMP2))
@@ -361,6 +366,7 @@ $(OBJDIR)/$(JO)findpts_el_2.o    :$(J)/findpts_el_2.c;    $(CC) -c $(cFL2) $(JL)
 #$(OBJDIR)/ssygv.o     	:$S/3rd_party/ssygv.F90;  	$(F77) -c $(FL2i4) $< -o $@
 # SYSTEM BLAS?
 #$(OBJDIR)/blas.o   	:$S/3rd_party/blas.F90;		$(F77) -c $(FL2i4) $< -o $@
+$(OBJDIR)/lz4.o             :$S/lz4.c;          $(CC) -c $(cFL2) $(JL) $< -o $@
 $(OBJDIR)/moab.o        :$S/3rd_party/moab.F90;           $(F77) -c $(FL2) $(IMESH_INCLUDES) $< -o $@
 $(OBJDIR)/imeshutil.o   :$S/3rd_party/imeshutil.F90;  	$(F77) -c $(FL2) $(IMESH_INCLUDES) $< -o $@
 $(OBJDIR)/imeshcutil.o   :$S/3rd_party/imeshcutil.c;  	$(CC) -c $(cFL2) $< -o $@

--- a/makenek.inc
+++ b/makenek.inc
@@ -20,6 +20,7 @@ if [ "$PPLIST" == "?" ]; then
   echo "  BLAS_MXM  disable nek-supplied BLAS routines"
   echo "  EXTBAR    adds underscore to exit call(for BGQ)"
   echo "  LZ4COMPRESSION lossless compression of output using lz4"
+  echo "  LZ4COMMCOMP lossless compression of output using lz4 on compute nodes"
   echo "  XSMM      uses libxsmm for small matrix multiplies"
   exit 1
 fi
@@ -62,6 +63,7 @@ SOURCE_ROOT=$APATH_SRC
 IFMOAB=false
 IFNEKNEK=false
 IFLZ4=false
+IFLZ4COMMCOMP=false
 
 # do some basic checks
 if [ "$CASEDIR" == "$SOURCE_ROOT" ]; then
@@ -298,6 +300,10 @@ if [ "$i" == "LZ4COMPRESSION" ]; then
      IFLZ4=true
 fi
 
+if [ "$i" == "LZ4COMMCOMP" ]; then
+     IFLZ4COMMCOMP=true
+fi
+
    if [ "$i" == "CVODE" ]; then
     if [ "$CVODE_DIR" == "" ]; then
        echo "ABORT: Please specify path to CVODE in CVODE_DIR!" 
@@ -429,6 +435,7 @@ sed -e "s:^F77[ ]*=.*:F77\:=$F77:" \
 -e "s:^MOAB_DIR[ ]*=.*:MOAB_DIR\:=${MOAB_DIR}:" \
 -e "s/^IFNEKNEK[ ]*=.*/IFNEKNEK:=$IFNEKNEK/" \
 -e "s/^IFLZ4[ ]*=.*/IFLZ4:=$IFLZ4/" \
+-e "s/^IFLZ4COMMCOMP[ ]*=.*/IFLZ4COMMCOMP:=$IFLZ4COMMCOMP/" \
 -e "s:^USR[ ]*=.*:USR\:=$USR:" \
 -e "s:^USR_LFLAGS[ ]*=.*:USR_LFLAGS\:=$USR_LFLAGS:" \
 -e "s:^S[ ]*=.*:S\:=${SOURCE_ROOT}:" $SOURCE_ROOT/makefile.template >.makefile

--- a/prepost.F90
+++ b/prepost.F90
@@ -1490,8 +1490,8 @@ subroutine mfo_outs(u,nel,mx,my,mz)
         sizein=nout*4
         sizeout=0
         call lz4_pack(u4, sizein, u4comp, sizeout, ierr)
-        call byte_write(u4comp,(sizeout+4)/4,ierr)
         call byte_write(sizeout,1,ierr)
+        call byte_write(u4comp,(sizeout+4)/4,ierr)
 #else
         nout = wdsizo/4 * ntot
         call byte_write(u4,nout,ierr)          ! u4 :=: u8
@@ -1502,8 +1502,8 @@ subroutine mfo_outs(u,nel,mx,my,mz)
         sizein=nout*4
         sizeout=0
         call lz4_pack(u8, sizein, u8comp, sizeout, ierr)
-        call byte_write(u8comp,(sizeout+4)/4,ierr)
         call byte_write(sizeout,1,ierr)
+        call byte_write(u8comp,(sizeout+4)/4,ierr)
 #else
         nout = wdsizo/4 * ntot
         call byte_write(u8,nout,ierr)          ! u4 :=: u8
@@ -1521,13 +1521,13 @@ subroutine mfo_outs(u,nel,mx,my,mz)
           if (wdsizo == 4 .AND. ierr == 0) then
             call crecv(mtype,u4,len)
             nout = (leocomp+4)/4 ! bytes devided by size of float (SP)
-            call byte_write(u4,nout,ierr) ! write also first byte as it does not contain nel
             call byte_write(leocomp,1,ierr)
+            call byte_write(u4,nout,ierr) ! write also first byte as it does not contain nel
           elseif(ierr == 0) then
             call crecv(mtype,u8,len)
             nout = (leocomp+4)/4 ! bytes devided by size of float (SP)
-            call byte_write(u8,nout,ierr)
             call byte_write(leocomp,1,ierr)
+            call byte_write(u8,nout,ierr)
           endif
 #else
           call csend(mtype,idum,4,k,0)       ! handshake
@@ -1549,7 +1549,7 @@ subroutine mfo_outs(u,nel,mx,my,mz)
         u4(1)= nel
         call copyx4 (u4(3),u,ntot)
         mtype = nid
-        call lz4_pack(u4(3), leo-1, u4comp, leocomp, ierr)
+        call lz4_pack(u4(3), leo-4, u4comp, leocomp, ierr)
         call crecv(mtype,idum,4)            ! hand-shake
         call csend(mtype,leocomp,4,pid0,0)     ! u4 :=: u8
         call csend(mtype,u4comp,leocomp,pid0,0)     ! u4 :=: u8
@@ -1557,7 +1557,7 @@ subroutine mfo_outs(u,nel,mx,my,mz)
         u8(1)= nel
         call copy (u8(2),u,ntot)
         mtype = nid
-        call lz4_pack(u8(2), leo-1, u8comp, leocomp, ierr)
+        call lz4_pack(u8(2), leo-8, u8comp, leocomp, ierr)
         call crecv(mtype,idum,4)            ! hand-shake
         call csend(mtype,leocomp,4,pid0,0)     ! u4 :=: u8
         call csend(mtype,u8comp,leocomp,pid0,0)     ! u4 :=: u8
@@ -1665,8 +1665,8 @@ subroutine mfo_outv(u,v,w,nel,mx,my,mz)
         sizein=nout*4
         sizeout=0
         call lz4_pack(u4, sizein, u4comp, sizeout, ierr)
-        call byte_write(u4comp,(sizeout+4)/4,ierr)
         call byte_write(sizeout,1,ierr)
+        call byte_write(u4comp,(sizeout+4)/4,ierr)
 #else
         call byte_write(u4,nout,ierr)          ! u4 :=: u8
 #endif
@@ -1675,8 +1675,8 @@ subroutine mfo_outv(u,v,w,nel,mx,my,mz)
         sizein=nout*4
         sizeout=0
         call lz4_pack(u8, sizein, u8comp, sizeout, ierr)
-        call byte_write(u8comp,(sizeout+4)/4,ierr)
         call byte_write(sizeout,1,ierr)
+        call byte_write(u8comp,(sizeout+4)/4,ierr)
 #else
         call byte_write(u8,nout,ierr)          ! u4 :=: u8
 #endif
@@ -1691,13 +1691,13 @@ subroutine mfo_outv(u,v,w,nel,mx,my,mz)
           if (wdsizo == 4 .AND. ierr == 0) then
             call crecv(mtype,u4,len)
             nout = (leocomp+4)/4 ! bytes devided by size of float (SP)
-            call byte_write(u4,nout,ierr) ! write also first byte as it does not contain nel
             call byte_write(leocomp,1,ierr)
+            call byte_write(u4,nout,ierr) ! write also first byte as it does not contain nel
           elseif(ierr == 0) then
             call crecv(mtype,u8,len)
             nout = (leocomp+4)/4 ! bytes devided by size of float (SP)
-            call byte_write(u8,nout,ierr)
             call byte_write(leocomp,1,ierr)
+            call byte_write(u8,nout,ierr)
           endif
 #else
           call csend(mtype,idum,4,k,0)           ! handshake
@@ -1730,7 +1730,7 @@ subroutine mfo_outv(u,v,w,nel,mx,my,mz)
           enddo
         mtype = nid
 #ifdef LZ4COMMCOMP
-         call lz4_pack(u4(3), leo-1, u4comp, leocomp, ierr)
+         call lz4_pack(u4(3), leo-4, u4comp, leocomp, ierr)
          call crecv(mtype,idum,4)            ! hand-shake
          call csend(mtype,leocomp,4,pid0,0)     ! u4 :=: u8
          call csend(mtype,u4comp,leocomp,pid0,0)     ! u4 :=: u8
@@ -1753,7 +1753,7 @@ subroutine mfo_outv(u,v,w,nel,mx,my,mz)
           enddo
         mtype = nid
 #ifdef LZ4COMMCOMP
-         call lz4_pack(u8(2), leo-1, u8comp, leocomp, ierr)
+         call lz4_pack(u8(2), leo-8, u8comp, leocomp, ierr)
          call crecv(mtype,idum,4)            ! hand-shake
          call csend(mtype,leocomp,4,pid0,0)     ! u4 :=: u8
          call csend(mtype,u8comp,leocomp,pid0,0)     ! u4 :=: u8


### PR DESCRIPTION
This creates a new PPLIST option LZ4COMMCOMP. That way the compression happens on the compute nodes instead of the IO nodes. 

It only implements the write and should be considered highly experimental. Not sure it belongs into any "stable" branch. 

The read in nek is not symmetric at all. The io node collects all data in one message from all nodes and writes to disk. However, the io nodes reads the data and sends ELEMENT BY ELEMENT to each node. Not sure why this is so and this would be totally different with compressed data as the io node has no notion of elements in the compressed data it has just read.

tl;dr highly experimental write, implementation of read will take a while, please test whether it's worthwhile.